### PR TITLE
Allow for dynamic webhooks to be used by Slacked

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Then run the installer:
 
     $ bundle exec rails g slacked:install
 
-This will create a .env file in the root of the rails application. Specify the Webhook Url and the message to be sent.
+This will create a .env file in the root of the rails application. Specify the default Webhook Url and the message to be sent.
 
 ```ruby
 SLACK_WEBHOOK= "WEBHOOK_URL"
@@ -41,7 +41,7 @@ SLACK_DEFAULT_MESSAGE= "TEST"
 
 
 ## Usage
-Set the SLACK_WEBHOOK env variable with the value of the webhook which you want to send the messages.
+Set the SLACK_WEBHOOK env variable with the default value of the webhook which you want to send the messages. If you would like to send messages to different webhooks, you can do so by specifying the webhook url in the `config` parameter to `Slacked#post` or `Slacked#post_async`.
 If you want to send a unique message in your application like 'Application is running' you can set the SLACK_DEFAULT_MESSAGE and call the message methods without sending an argument.
 
 
@@ -82,7 +82,12 @@ or
 Slacked.post_async "Let's play fetch!", {icon_emoji: ':dog:'}
 ```
 
-Right now we only have the config for the icon, if you need another one let us know or submit a pull request.
+or
+```ruby
+Slacked.post_async 'This goes to a specific channel!', {webhook_url: <WEBHOOK_URL>}
+```
+
+Right now we only have the config for the icon and the webhook url, if you need another one let us know or submit a pull request.
 
 ## Example
 
@@ -107,11 +112,12 @@ config.slacked_disabled = true
 
 The default value is false
 
-## Contributors
+## Contributors 
 
 - [Kaio Magalhães](https://github.com/kaiomagalhaes)
 - [Lockyy](https://github.com/Lockyy)
 - [Sean H.](https://github.com/seathony)
+- [Tomas Barry](https://github.com/TomasBarry)
 
 
 ## License

--- a/lib/slacked/slack_post.rb
+++ b/lib/slacked/slack_post.rb
@@ -1,15 +1,20 @@
 module Slacked
   SLACK_PROFILE_IMAGE=':robot_face:'
-  SLACK_WEBHOOK_URL_KEY='SLACK_WEBHOOK'
+  SLACK_WEBHOOK_URL_KEY = 'SLACK_WEBHOOK'
   SLACK_DEFAULT_MESSAGE_KEY='SLACK_DEFAULT_MESSAGE'
-  SLACK_DEFAULT_CONFIG= {
-      icon_emoji: SLACK_PROFILE_IMAGE
-  }
+  SLACK_DEFAULT_CONFIG = {
+    icon_emoji: SLACK_PROFILE_IMAGE,
+    webhook_url: ENV[SLACK_WEBHOOK_URL_KEY]
+  }.freeze
 
   class << self
     def post message = ENV[SLACK_DEFAULT_MESSAGE_KEY], config = SLACK_DEFAULT_CONFIG
       return false if message.nil? || message.empty? || disabled?
-      slack_notifier.ping message, SLACK_DEFAULT_CONFIG.merge(config)
+
+      merged_configs = SLACK_DEFAULT_CONFIG.merge(config)
+      webhook_url = merged_configs.fetch(:webhook_url, SLACK_WEBHOOK_URL_KEY)
+      slack_notifier(webhook_url)
+        .ping(message, merged_configs)
     end
 
     def post_async message= ENV[SLACK_DEFAULT_MESSAGE_KEY], config = SLACK_DEFAULT_CONFIG
@@ -27,8 +32,9 @@ module Slacked
     end
 
     private
-    def slack_notifier webhook_url = ENV[SLACK_WEBHOOK_URL_KEY]
-      Slack::Notifier.new webhook_url
+
+    def slack_notifier(webhook_url)
+      Slack::Notifier.new(webhook_url)
     end
 
     def rails?

--- a/spec/slack_post_spec.rb
+++ b/spec/slack_post_spec.rb
@@ -23,8 +23,9 @@ describe Slacked do
     end
 
     it 'merges with the default config when config is passed' do
-      config =  {
-          icon_emoji: ':ghost:'
+      config = {
+        icon_emoji: ':ghost:',
+        webhook_url: 'WEBHOOK_URL'
       }
       expect_any_instance_of(Slack::Notifier).to receive(:ping).with(message, config).and_return(true)
       expect(Slacked.post(message, config)).to be_truthy


### PR DESCRIPTION
This commit introduces the ability for a user to set a dynamic webhook
url through the use of the `config` parameter to `Slacked#post` and
`Slacked#post_async`. By introducing this feature through the `config`
parameter, there are no breaking changes with previous versions of
Slacked.

The behaviour of Slacked is exactly the same as before, where Slacked
will use the default `ENV[SLACK_WEBHOOK_URL_KEY]` set in the `.env`
file. However, should you want to use `Slacked` to send messages to
different webhooks from a single Rails app, you can now do so:

```ruby
Slacked.post('My message to the default webhook') # this sends a message
to the default webhook url set by `ENV[SLACK_WEBHOOK_URL_KEY]` in the
`.env` file

Slacked.post('My message to a specific webhook url', { webhook_url:
'<SOME_WEBHOOK_URL>'}) # this sends a message to an explicit webhook url
```

The README and tests have been updated accordingly.